### PR TITLE
[TSG] Backporting PHP 7.1 Support for 2.1 (pr56) (2.1.16)

### DIFF
--- a/app/code/Magento/BundleSampleData/composer.json
+++ b/app/code/Magento/BundleSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-bundle-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~5.6.0|7.0.2|~7.0.6",
+        "php": "~5.6.0|7.0.2|~7.0.6|~7.1.0",
         "magento/module-bundle": "100.1.*",
         "magento/module-sample-data": "100.1.*",
         "magento/module-catalog-sample-data": "100.1.*"

--- a/app/code/Magento/CatalogRuleSampleData/composer.json
+++ b/app/code/Magento/CatalogRuleSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-catalog-rule-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~5.6.0|7.0.2|~7.0.6",
+        "php": "~5.6.0|7.0.2|~7.0.6|~7.1.0",
         "magento/module-catalog-rule": "100.1.*",
         "magento/module-sample-data": "100.1.*"
     },

--- a/app/code/Magento/CatalogSampleData/composer.json
+++ b/app/code/Magento/CatalogSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-catalog-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~5.6.0|7.0.2|~7.0.6",
+        "php": "~5.6.0|7.0.2|~7.0.6|~7.1.0",
         "magento/module-sample-data": "100.1.*"
     },
     "type": "magento2-module",

--- a/app/code/Magento/CmsSampleData/composer.json
+++ b/app/code/Magento/CmsSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-cms-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~5.6.0|7.0.2|~7.0.6",
+        "php": "~5.6.0|7.0.2|~7.0.6|~7.1.0",
         "magento/module-cms": "101.0.*",
         "magento/module-sample-data": "100.1.*",
         "magento/module-theme-sample-data": "100.1.*",

--- a/app/code/Magento/ConfigurableSampleData/composer.json
+++ b/app/code/Magento/ConfigurableSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-configurable-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~5.6.0|7.0.2|~7.0.6",
+        "php": "~5.6.0|7.0.2|~7.0.6|~7.1.0",
         "magento/module-configurable-product": "100.1.*",
         "magento/module-sample-data": "100.1.*",
         "magento/module-product-links-sample-data": "100.1.*"

--- a/app/code/Magento/CustomerSampleData/composer.json
+++ b/app/code/Magento/CustomerSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-customer-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~5.6.0|7.0.2|~7.0.6",
+        "php": "~5.6.0|7.0.2|~7.0.6|~7.1.0",
         "magento/module-sample-data": "100.1.*"
     },
     "type": "magento2-module",

--- a/app/code/Magento/DownloadableSampleData/composer.json
+++ b/app/code/Magento/DownloadableSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-downloadable-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~5.6.0|7.0.2|~7.0.6",
+        "php": "~5.6.0|7.0.2|~7.0.6|~7.1.0",
         "magento/module-sample-data": "100.1.*",
         "magento/module-catalog-sample-data": "100.1.*",
         "magento/module-downloadable": "100.1.*",

--- a/app/code/Magento/GroupedProductSampleData/composer.json
+++ b/app/code/Magento/GroupedProductSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-grouped-product-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~5.6.0|7.0.2|~7.0.6",
+        "php": "~5.6.0|7.0.2|~7.0.6|~7.1.0",
         "magento/module-sample-data": "100.1.*",
         "magento/module-catalog-sample-data": "100.1.*",
         "magento/module-grouped-product": "100.1.*"

--- a/app/code/Magento/MsrpSampleData/composer.json
+++ b/app/code/Magento/MsrpSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-msrp-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~5.6.0|7.0.2|~7.0.6",
+        "php": "~5.6.0|7.0.2|~7.0.6|~7.1.0",
         "magento/module-sample-data": "100.1.*",
         "magento/module-msrp": "100.1.*"
     },

--- a/app/code/Magento/OfflineShippingSampleData/composer.json
+++ b/app/code/Magento/OfflineShippingSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-offline-shipping-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~5.6.0|7.0.2|~7.0.6",
+        "php": "~5.6.0|7.0.2|~7.0.6|~7.1.0",
         "magento/module-sample-data": "100.1.*",
         "magento/module-offline-shipping": "100.1.*",
         "magento/module-directory": "100.1.*"

--- a/app/code/Magento/ProductLinksSampleData/composer.json
+++ b/app/code/Magento/ProductLinksSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-product-links-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~5.6.0|7.0.2|~7.0.6",
+        "php": "~5.6.0|7.0.2|~7.0.6|~7.1.0",
         "magento/module-catalog-sample-data": "100.1.*",
         "magento/module-sample-data": "100.1.*"
     },

--- a/app/code/Magento/ReviewSampleData/composer.json
+++ b/app/code/Magento/ReviewSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-review-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~5.6.0|7.0.2|~7.0.6",
+        "php": "~5.6.0|7.0.2|~7.0.6|~7.1.0",
         "magento/module-sample-data": "100.1.*",
         "magento/module-review": "100.1.*"
     },

--- a/app/code/Magento/SalesRuleSampleData/composer.json
+++ b/app/code/Magento/SalesRuleSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-sales-rule-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~5.6.0|7.0.2|~7.0.6",
+        "php": "~5.6.0|7.0.2|~7.0.6|~7.1.0",
         "magento/module-sample-data": "100.1.*",
         "magento/module-catalog-rule-sample-data": "100.1.*",
         "magento/module-sales-rule": "100.1.*",

--- a/app/code/Magento/SalesSampleData/composer.json
+++ b/app/code/Magento/SalesSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-sales-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~5.6.0|7.0.2|~7.0.6",
+        "php": "~5.6.0|7.0.2|~7.0.6|~7.1.0",
         "magento/module-sales": "100.1.*",
         "magento/module-sample-data": "100.1.*",
         "magento/module-configurable-sample-data": "100.1.*"

--- a/app/code/Magento/SwatchesSampleData/composer.json
+++ b/app/code/Magento/SwatchesSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-swatches-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~5.6.0|7.0.2|~7.0.6",
+        "php": "~5.6.0|7.0.2|~7.0.6|~7.1.0",
         "magento/module-swatches": "100.1.*",
         "magento/module-sample-data": "100.1.*",
         "magento/module-eav": "100.1.*"

--- a/app/code/Magento/TaxSampleData/composer.json
+++ b/app/code/Magento/TaxSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-tax-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~5.6.0|7.0.2|~7.0.6",
+        "php": "~5.6.0|7.0.2|~7.0.6|~7.1.0",
         "magento/module-tax": "100.1.*",
         "magento/module-sample-data": "100.1.*"
     },

--- a/app/code/Magento/ThemeSampleData/composer.json
+++ b/app/code/Magento/ThemeSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-theme-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~5.6.0|7.0.2|~7.0.6",
+        "php": "~5.6.0|7.0.2|~7.0.6|~7.1.0",
         "magento/module-theme": "100.1.*",
         "magento/module-sample-data": "100.1.*"
     },

--- a/app/code/Magento/WidgetSampleData/composer.json
+++ b/app/code/Magento/WidgetSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-widget-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~5.6.0|7.0.2|~7.0.6",
+        "php": "~5.6.0|7.0.2|~7.0.6|~7.1.0",
         "magento/module-widget": "100.1.*",
         "magento/module-sample-data": "100.1.*",
         "magento/module-theme": "100.1.*",

--- a/app/code/Magento/WishlistSampleData/composer.json
+++ b/app/code/Magento/WishlistSampleData/composer.json
@@ -2,7 +2,7 @@
     "name": "magento/module-wishlist-sample-data",
     "description": "N/A",
     "require": {
-        "php": "~5.6.0|7.0.2|~7.0.6",
+        "php": "~5.6.0|7.0.2|~7.0.6|~7.1.0",
         "magento/module-wishlist": "100.1.*",
         "magento/module-sample-data": "100.1.*"
     },


### PR DESCRIPTION
## Scope

### Bug - P1
* [MAGETWO-92836](https://jira.corp.magento.com/browse/MAGETWO-92836) [Backport for 2.1.x] Support for PHP 7.1

### Bamboo CI builds

* [x] [M2 L4 (PHP 5.5)](https://bamboo.corp.magento.com/browse/MCCE21DEV-L41049/latest)
* [x] [PAT](https://bamboo.corp.magento.com/browse/MCCE21DEV-PAT402/latest)

### Related Pull Requests

- CE https://github.com/magento-tsg/magento2ce/pull/226
- EE https://github.com/magento-tsg/magento2ee/pull/158
- Infrastructure https://github.com/magento-tsg/magento2-infrastructure/pull/41
- Sample Data EE https://github.com/magento-tsg/magento2-sample-data-ee/pull/1
- MTF https://github.com/magento-tsg/mtf/pull/4

### CE Checklist

- [ ] PR is green on M2 Quality Portal
- [ ] Jira issues have accurate summary, meaningful description and have links to relevant documentation at the story/task level
- [ ] Semantic Version build failure is approved by architect (if build is red) <Architect Name>
- [ ] Pull Request approved by architect <Architect Name>
- [ ] Pull Request quality review performed by <name>
- [ ] All unstable functional acceptance tests are isolated (if any)
- [ ] All linked Zephyr tests are approved by PO and have Ready to Use status
- [ ] Travis CI build is green (for mainline CE only)
- [ ] Jenkins Unit, Extended FAT CE, Extended FAT EE and Extended FAT B2B builds are green
